### PR TITLE
Only eval between triple ticks when present

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -82,6 +82,7 @@ func RemoveTripleBackticks(s string) string {
 	// Extract the code in between triple backticks, ignoring the language tag if any.
 	buf := strings.Builder{}
 	first := true
+	needNewline := false
 	for {
 		i := strings.Index(s, "```")
 		if i == -1 {
@@ -90,8 +91,8 @@ func RemoveTripleBackticks(s string) string {
 			}
 			break
 		}
-		if first {
-			buf.WriteString("\n") // separate from previous
+		if needNewline {
+			buf.WriteString("\n") // separate from previous set that didn't end with a newline.
 		}
 		first = false
 		s = s[i:]
@@ -103,6 +104,7 @@ func RemoveTripleBackticks(s string) string {
 			buf.WriteString(s)
 			break
 		}
+		needNewline = (s[j-1] != '\n')
 		buf.WriteString(s[:j])
 		s = s[j+3:]
 	}

--- a/bot_test.go
+++ b/bot_test.go
@@ -54,7 +54,7 @@ b=2
 ` + "```" + `
 some stuff after code
 ` + "```c=3``` and ```d=4```",
-			"a=1\nb=2\nc=3",
+			"a=1\nb=2\nc=3\nd=4",
 		},
 	}
 	for _, test := range tests {

--- a/bot_test.go
+++ b/bot_test.go
@@ -28,3 +28,37 @@ func TestUptime(t *testing.T) {
 		t.Errorf("Expected %v, but got %v", expected, actual)
 	}
 }
+
+func TestRemoveBackticks(t *testing.T) {
+	// table driven inpute,expected
+	tests := []struct {
+		input, expected string
+	}{
+		{"   foo   \n   bar   ", "foo   \n   bar"},
+		{`
+this is before code
+` + "```go" + `
+a=1
+b=2
+` + "```" + `
+some stuff after code`,
+			"a=1\nb=2",
+		},
+		{`
+this is before code
+` + "```go" + `
+a=1
+b=2
+` + "```" + `
+some stuff after code
+` + "```c=3``` and ```d=4```",
+			"a=1\nb=2\nc=3",
+		},
+	}
+	for _, test := range tests {
+		actual := bot.RemoveTripleBackticks(test.input)
+		if actual != test.expected {
+			t.Errorf("---For---\n%s\n---Expected %q, but got %q", test.input, test.expected, actual)
+		}
+	}
+}

--- a/bot_test.go
+++ b/bot_test.go
@@ -35,7 +35,8 @@ func TestRemoveBackticks(t *testing.T) {
 		input, expected string
 	}{
 		{"   foo   \n   bar   ", "foo   \n   bar"},
-		{`
+		{
+			`
 this is before code
 ` + "```go" + `
 a=1
@@ -44,7 +45,8 @@ b=2
 some stuff after code`,
 			"a=1\nb=2",
 		},
-		{`
+		{
+			`
 this is before code
 ` + "```go" + `
 a=1

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module grol.io/grol-discord-bot
 go 1.22.5
 
 require (
-	fortio.org/cli v1.7.0
+	fortio.org/cli v1.8.0
 	fortio.org/log v1.16.0
 	fortio.org/scli v1.15.1
 	fortio.org/version v1.0.4
 	github.com/bwmarrin/discordgo v0.28.1
-	grol.io/grol v0.26.0
+	grol.io/grol v0.27.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 fortio.org/assert v1.2.1 h1:48I39urpeDj65RP1KguF7akCjILNeu6vICiYMEysR7Q=
 fortio.org/assert v1.2.1/go.mod h1:039mG+/iYDPO8Ibx8TrNuJCm2T2SuhwRI3uL9nHTTls=
-fortio.org/cli v1.7.0 h1:w+uXZLGi4t3Vn/BvbeMuSw84Z1pvNPG9HqeGfpP68cc=
-fortio.org/cli v1.7.0/go.mod h1:s4vxWz7P7T4cYOWdMF0NA693Nu1gK9OW4KoDj54/Do4=
+fortio.org/cli v1.8.0 h1:Mz1phmUwkQaXESGb1nIWBY+CHli/GYIlhwpktorh9sY=
+fortio.org/cli v1.8.0/go.mod h1:pk/JBE8LcXtNuo5Yj2bLsVbwPaHo8NWdbstSN0cpbFk=
 fortio.org/dflag v1.7.2 h1:lUhXFvDlw4CJj/q7hPv/TC+n/wVoQylzQO6bUg5GQa0=
 fortio.org/dflag v1.7.2/go.mod h1:6yO/NIgrWfQH195WbHJ3Y45SCx11ffivQjfx2C/FS1U=
 fortio.org/log v1.16.0 h1:GhU8/9NkYZmEIzvTN/DTMedDAStLJraWUUVUA2EbNDc=
@@ -39,5 +39,5 @@ golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-grol.io/grol v0.26.0 h1:rrsWd0EhnEr8V+hiEU8Zvb5DBaiBvv1jS+T0v36faQM=
-grol.io/grol v0.26.0/go.mod h1:rRHlaB49q2Qgf2Zz2SfbkFzk9h+acpFbe7oCXqI9PiM=
+grol.io/grol v0.27.0 h1:9x/hAyP3DhRkGSX24eqlPNI6aPBRCR+bfKHV+hMoOT4=
+grol.io/grol v0.27.0/go.mod h1:sZnaBD2XrNWV3t+wthpch957qOE7RkT1YIIID9ICMhQ=


### PR DESCRIPTION
works even for
````md
Some normal text
```a``` and ```b```
more normal text
````
ie will yield
```
a
b
```

fixes #30