### PR TITLE
Because extensions addition isn't in init(), need to call it explictly

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -26,7 +26,10 @@ const Unknown = "unknown"
 
 func Run(maxHistoryLength int) {
 	botStartTime = time.Now()
-	extensions.Init()
+	err := extensions.Init()
+	if err != nil {
+		log.Fatalf("Grol extensions init error: %v", err)
+	}
 	msgSet = fixedmap.NewFixedMap[string, string](maxHistoryLength)
 	// create a session
 	session, err := discordgo.New("Bot " + BotToken)

--- a/bot.go
+++ b/bot.go
@@ -11,6 +11,7 @@ import (
 	"fortio.org/version"
 	"github.com/bwmarrin/discordgo"
 	"grol.io/grol-discord-bot/fixedmap"
+	"grol.io/grol/extensions"
 	"grol.io/grol/repl"
 )
 
@@ -25,6 +26,7 @@ const Unknown = "unknown"
 
 func Run(maxHistoryLength int) {
 	botStartTime = time.Now()
+	extensions.Init()
 	msgSet = fixedmap.NewFixedMap[string, string](maxHistoryLength)
 	// create a session
 	session, err := discordgo.New("Bot " + BotToken)


### PR DESCRIPTION
it's your fault @ccoVeille that bot 0.20.0 doesn't have math stuff :)

fix is easy enough but makes me think extensions init should really be built in to grol default behavior