### PR TITLE
Harden the service, use the memory limit from grol 0.51+ to avoid fatal/crashes, limit length of values in state file

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -227,13 +227,14 @@ func eval(input string, formatMode, compactMode, verbatimMode bool) string {
 		// in a single message and not get errors on the extra text (meanwhile, add //).
 		input = RemoveTripleBackticks(input)
 		cfg := repl.Options{
-			All:      true,
-			ShowEval: true,
-			NoColor:  true,
-			Compact:  compactMode,
-			AutoLoad: AutoLoadSave,
-			AutoSave: AutoLoadSave,
-			MaxDepth: *depth,
+			All:         true,
+			ShowEval:    true,
+			NoColor:     true,
+			Compact:     compactMode,
+			AutoLoad:    AutoLoadSave,
+			AutoSave:    AutoLoadSave,
+			MaxDepth:    *depth,
+			MaxValueLen: *maxLen,
 		}
 		// Turn smart quotes back into regular quotes - https://github.com/grol-io/grol-discord-bot/issues/57
 		input = SmartQuotesToRegular(input)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	grol.io/grol v0.50.0
 )
 
-// replace grol.io/grol => ../grol
+replace grol.io/grol => ../grol
 
 require (
 	fortio.org/dflag v1.7.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,10 @@ require (
 	fortio.org/scli v1.15.2
 	fortio.org/version v1.0.4
 	github.com/bwmarrin/discordgo v0.28.1
-	grol.io/grol v0.50.0
+	grol.io/grol v0.51.1
 )
 
-replace grol.io/grol => ../grol
+// replace grol.io/grol => ../grol
 
 require (
 	fortio.org/dflag v1.7.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,5 +43,5 @@ golang.org/x/sys v0.24.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-grol.io/grol v0.50.0 h1:S9lDqa0AN56khzX91HDjsFXGHsuaVlRycb4+Pp1WFKU=
-grol.io/grol v0.50.0/go.mod h1:auvyNPGD+C1jMFsu+EkAVmXCjweP9qRLoTIYtdfrWiI=
+grol.io/grol v0.51.1 h1:42zjPRe3/2oTvhQZALY2A1soMhKl7bbKhNy/sA0nIbM=
+grol.io/grol v0.51.1/go.mod h1:auvyNPGD+C1jMFsu+EkAVmXCjweP9qRLoTIYtdfrWiI=

--- a/grol.service
+++ b/grol.service
@@ -26,7 +26,9 @@ PrivateDevices=true
 # ProtectHome=true
 PrivateTmp=true
 # Place the DISCORD_BOT_TOKEN= in that file and chmod 400 it.
+# Note: should use LoadCredential= instead as this isn't very secure.
 EnvironmentFile=/home/ubuntu/grol-discord-bot/.dtoken
+Environment=GOMEMLIMIT=1G
 
 [Install]
 WantedBy=multi-user.target

--- a/grol.service
+++ b/grol.service
@@ -17,6 +17,14 @@ WorkingDirectory=/home/ubuntu/grol-discord-bot
 ExecStart=/home/ubuntu/go/bin/grol-discord-bot
 Restart=always
 RestartSec=1
+# Security hardening
+CapabilityBoundingSet=
+AmbientCapabilities=
+NoNewPrivileges=true
+ProtectSystem=strict
+PrivateDevices=true
+# ProtectHome=true
+PrivateTmp=true
 # Place the DISCORD_BOT_TOKEN= in that file and chmod 400 it.
 EnvironmentFile=/home/ubuntu/grol-discord-bot/.dtoken
 

--- a/grol.service
+++ b/grol.service
@@ -28,7 +28,10 @@ PrivateTmp=true
 # Place the DISCORD_BOT_TOKEN= in that file and chmod 400 it.
 # Note: should use LoadCredential= instead as this isn't very secure.
 EnvironmentFile=/home/ubuntu/grol-discord-bot/.dtoken
-Environment=GOMEMLIMIT=1G
+Environment=GOMEMLIMIT=1GiB
+# Don't let it go too much above the soft limit (newer grol has memory checks too)
+MemoryHigh=1.5G
+MemoryMax=2G
 
 [Install]
 WantedBy=multi-user.target

--- a/main.go
+++ b/main.go
@@ -2,13 +2,18 @@ package main
 
 import (
 	"flag"
+	"math"
 	"os"
+	"runtime/debug"
 
 	"fortio.org/log"
 	"fortio.org/scli"
 )
 
-var depth = flag.Int("max-depth", 10000, "Maximum depth of recursion")
+var (
+	depth  = flag.Int("max-depth", 10000, "Maximum depth of recursion")
+	maxLen = flag.Int("max-save-len", 1000, "Maximum len of saved identifiers, use 0 for unlimited")
+)
 
 func main() {
 	num := flag.Int("n", 100, "Maximum number of messages to keep in memory for possible edit")
@@ -18,5 +23,9 @@ func main() {
 		log.Fatalf("DISCORD_BOT_TOKEN must be set")
 	}
 	AutoLoadSave = !(os.Getenv("GROL_DISABLE_AUTOSAVE") == "1")
+	memlimit := debug.SetMemoryLimit(-1)
+	if memlimit == math.MaxInt64 {
+		log.Fatalf("Memory limit not set, please set GOMEMLIMIT=1GiB or similar")
+	}
 	Run(*num)
 }


### PR DESCRIPTION
- systemd per discord gophers reco
- avoid crashes with "abc" * 10_000_000_000 - no more `fatal error: runtime: out of memory` instead a nice: 
```
panic: would exceed memory requesting 1875000000 objects, 1072372592 free
```
- limit length of values in autosave .gr to 1000 (per)